### PR TITLE
Update domain references to backupbot.is-cool.dev

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,8 +8,8 @@
     <meta name="author" content="Andres99">
     <meta property="og:title" content="BackupBot - 404 Not found">
     <meta property="og:description" content="the page you looking for ain't existing.">
-    <meta property="og:image" content="https://backupbot.net/images/404.jpg"> 
-    <meta property="og:url" content="https://backupbot.net/404">
+    <meta property="og:image" content="https://backupbot.is-cool.dev/images/404.jpg"> 
+    <meta property="og:url" content="https://backupbot.is-cool.dev/404">
     <meta name="twitter:card" content="summary_large_image">
     <title>BackupBot - 404 Not Found</title>
     <link rel="icon" href="images/BackupBot.png" type="image/png">
@@ -26,19 +26,19 @@
         <div class="flex justify-between items-center mb-8">
             <div class="flex items-center space-x-2">
                 <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-10 h-10" loading="lazy">
-                <a href="https://backupbot.net/" class="text-xl font-bold text-gray-800">BackupBot</a>
+                <a href="https://backupbot.is-cool.dev/" class="text-xl font-bold text-gray-800">BackupBot</a>
             </div>
             <button id="closeMenu" class="text-gray-500 hover:text-gray-700">
                 <i class="fas fa-times text-2xl"></i>
             </button>
         </div>
         <div class="flex flex-col space-y-4">
-            <a href="https://backupbot.net/#features" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Features</a>
-            <a href="https://backupbot.net/#how-to-use" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">How To Use</a>
-            <a href="https://backupbot.net/#commands" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Commands</a>
-            <a href="https://backupbot.net/#faq" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">FAQ</a>
-            <a href="https://backupbot.net/#to-add" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Roadmap</a>
-            <a href="https://backupbot.net/#developer" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Developer</a>
+            <a href="https://backupbot.is-cool.dev/#features" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Features</a>
+            <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">How To Use</a>
+            <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Commands</a>
+            <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">FAQ</a>
+            <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Roadmap</a>
+            <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Developer</a>
             <a href="./privacy" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Privacy Policy</a>
             <a href="./terms" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Terms of Service</a>
             <a href="./cookies" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Cookie Policy</a>
@@ -50,7 +50,7 @@
                     </div>
                 </div>
             </div>
-            <a href="https://backupbot.net/" class="bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 transition-colors mt-4 text-center">
+            <a href="https://backupbot.is-cool.dev/" class="bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 transition-colors mt-4 text-center">
                 Return to Home
             </a>
         </div>
@@ -60,15 +60,15 @@
         <div class="container mx-auto px-6 py-3 flex justify-between items-center">
             <div class="flex items-center space-x-2">
                 <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-10 h-10" loading="lazy">
-                <a href="https://backupbot.net/" class="text-xl font-bold text-gray-800 hover:text-indigo-600 transition-colors">BackupBot</a>
+                <a href="https://backupbot.is-cool.dev/" class="text-xl font-bold text-gray-800 hover:text-indigo-600 transition-colors">BackupBot</a>
             </div>
             <div class="hidden md:flex space-x-6">
-                <a href="https://backupbot.net/#features" class="text-gray-700 hover:text-indigo-600 transition-colors">Features</a>
-                <a href="https://backupbot.net/#how-to-use" class="text-gray-700 hover:text-indigo-600 transition-colors">How To Use</a>
-                <a href="https://backupbot.net/#commands" class="text-gray-700 hover:text-indigo-600 transition-colors">Commands</a>
-                <a href="https://backupbot.net/#faq" class="text-gray-700 hover:text-indigo-600 transition-colors">FAQ</a>
-                <a href="https://backupbot.net/#to-add" class="text-gray-700 hover:text-indigo-600 transition-colors">Roadmap</a>
-                <a href="https://backupbot.net/#developer" class="text-gray-700 hover:text-indigo-600 transition-colors">Developer</a>
+                <a href="https://backupbot.is-cool.dev/#features" class="text-gray-700 hover:text-indigo-600 transition-colors">Features</a>
+                <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-700 hover:text-indigo-600 transition-colors">How To Use</a>
+                <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-700 hover:text-indigo-600 transition-colors">Commands</a>
+                <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-700 hover:text-indigo-600 transition-colors">FAQ</a>
+                <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-700 hover:text-indigo-600 transition-colors">Roadmap</a>
+                <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-700 hover:text-indigo-600 transition-colors">Developer</a>
                 <a href="./privacy" class="text-gray-700 hover:text-indigo-600 transition-colors">Privacy</a>
                 <a href="./terms" class="text-gray-700 hover:text-indigo-600 transition-colors">Terms</a>
                 <a href="./cookies" class="text-gray-700 hover:text-indigo-600 transition-colors">Cookies</a>
@@ -94,7 +94,7 @@
             <h2 class="text-3xl md:text-4xl font-bold mb-6 fade-in">Page Not Found</h2>
             <p class="text-xl mb-8 max-w-3xl mx-auto fade-in">The page you're looking for doesn't exist or has been moved to another URL of ours</p>
             <div class="flex justify-center fade-in">
-                <a href="https://backupbot.net/" class="bg-white text-indigo-600 px-8 py-4 rounded-md font-semibold hover:bg-gray-100 transition-colors btn">
+                <a href="https://backupbot.is-cool.dev/" class="bg-white text-indigo-600 px-8 py-4 rounded-md font-semibold hover:bg-gray-100 transition-colors btn">
                     Go Back to Home <i class="fas fa-home ml-2"></i>
                 </a>
             </div>
@@ -124,15 +124,15 @@
             <div class="flex flex-col md:flex-row justify-between items-center">
                 <div class="flex items-center space-x-2 mb-6 md:mb-0">
                     <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-12 h-12" loading="lazy">
-                    <a href="https://backupbot.net/" class="text-2xl font-bold text-white hover:text-gray-300 transition-colors">BackupBot</a>
+                    <a href="https://backupbot.is-cool.dev/" class="text-2xl font-bold text-white hover:text-gray-300 transition-colors">BackupBot</a>
                 </div>
                 <div class="flex flex-wrap justify-center gap-4 mb-6 md:mb-0">
-                    <a href="https://backupbot.net/#features" class="text-gray-400 hover:text-white transition-colors">Features</a>
-                    <a href="https://backupbot.net/#how-to-use" class="text-gray-400 hover:text-white transition-colors">How To Use</a>
-                    <a href="https://backupbot.net/#commands" class="text-gray-400 hover:text-white transition-colors">Commands</a>
-                    <a href="https://backupbot.net/#faq" class="text-gray-400 hover:text-white transition-colors">FAQ</a>
-                    <a href="https://backupbot.net/#to-add" class="text-gray-400 hover:text-white transition-colors">Roadmap</a>
-                    <a href="https://backupbot.net/#developer" class="text-gray-400 hover:text-white transition-colors">Developer</a>
+                    <a href="https://backupbot.is-cool.dev/#features" class="text-gray-400 hover:text-white transition-colors">Features</a>
+                    <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-400 hover:text-white transition-colors">How To Use</a>
+                    <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-400 hover:text-white transition-colors">Commands</a>
+                    <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-400 hover:text-white transition-colors">FAQ</a>
+                    <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-400 hover:text-white transition-colors">Roadmap</a>
+                    <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-400 hover:text-white transition-colors">Developer</a>
                     <a href="./privacy" class="text-gray-400 hover:text-white transition-colors">Privacy Policy</a>
                     <a href="./terms" class="text-gray-400 hover:text-white transition-colors">Terms of Service</a>
                     <a href="./cookies" class="text-gray-400 hover:text-white transition-colors">Cookie Policy</a>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-## https://backupbot.net/
+## https://backupbot.is-cool.dev/
 
 > This website is licenced under the GNU Affero General Public License v3.0:
-> - [View license here](https://github.com/BackupBotlol/backupbot.net/blob/main/LICENSE)
-> - [Download license here](https://backupbot.net/LICENSE)
+> - [View license here](https://github.com/BackupBotlol/backupbot.is-cool.dev/blob/main/LICENSE)
+> - [Download license here](https://backupbot.is-cool.dev/LICENSE)

--- a/cookies.html
+++ b/cookies.html
@@ -21,19 +21,19 @@
         <div class="flex justify-between items-center mb-8">
             <div class="flex items-center space-x-2">
                 <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-10 h-10" loading="lazy">
-                <a href="https://backupbot.net/" class="text-xl font-bold text-gray-800">BackupBot</a>
+                <a href="https://backupbot.is-cool.dev/" class="text-xl font-bold text-gray-800">BackupBot</a>
             </div>
             <button id="closeMenu" class="text-gray-500 hover:text-gray-700">
                 <i class="fas fa-times text-2xl"></i>
             </button>
         </div>
         <div class="flex flex-col space-y-4">
-            <a href="https://backupbot.net/#features" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Features</a>
-            <a href="https://backupbot.net/#how-to-use" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">How To Use</a>
-            <a href="https://backupbot.net/#commands" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Commands</a>
-            <a href="https://backupbot.net/#faq" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">FAQ</a>
-            <a href="https://backupbot.net/#to-add" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Roadmap</a>
-            <a href="https://backupbot.net/#developer" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Developer</a>
+            <a href="https://backupbot.is-cool.dev/#features" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Features</a>
+            <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">How To Use</a>
+            <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Commands</a>
+            <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">FAQ</a>
+            <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Roadmap</a>
+            <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Developer</a>
             <a href="./privacy" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Privacy Policy</a>
             <a href="./terms" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Terms of Service</a>
             <a href="./cookies" class="text-indigo-600 font-medium py-2 border-b border-gray-200">Cookie Policy</a>
@@ -55,15 +55,15 @@
         <div class="container mx-auto px-6 py-3 flex justify-between items-center">
             <div class="flex items-center space-x-2">
                 <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-10 h-10" loading="lazy">
-                <a href="https://backupbot.net/" class="text-xl font-bold text-gray-800 hover:text-indigo-600 transition-colors">BackupBot</a>
+                <a href="https://backupbot.is-cool.dev/" class="text-xl font-bold text-gray-800 hover:text-indigo-600 transition-colors">BackupBot</a>
             </div>
             <div class="hidden md:flex space-x-6">
-                <a href="https://backupbot.net/#features" class="text-gray-700 hover:text-indigo-600 transition-colors">Features</a>
-                <a href="https://backupbot.net/#how-to-use" class="text-gray-700 hover:text-indigo-600 transition-colors">How To Use</a>
-                <a href="https://backupbot.net/#commands" class="text-gray-700 hover:text-indigo-600 transition-colors">Commands</a>
-                <a href="https://backupbot.net/#faq" class="text-gray-700 hover:text-indigo-600 transition-colors">FAQ</a>
-                <a href="https://backupbot.net/#to-add" class="text-gray-700 hover:text-indigo-600 transition-colors">Roadmap</a>
-                <a href="https://backupbot.net/#developer" class="text-gray-700 hover:text-indigo-600 transition-colors">Developer</a>
+                <a href="https://backupbot.is-cool.dev/#features" class="text-gray-700 hover:text-indigo-600 transition-colors">Features</a>
+                <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-700 hover:text-indigo-600 transition-colors">How To Use</a>
+                <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-700 hover:text-indigo-600 transition-colors">Commands</a>
+                <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-700 hover:text-indigo-600 transition-colors">FAQ</a>
+                <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-700 hover:text-indigo-600 transition-colors">Roadmap</a>
+                <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-700 hover:text-indigo-600 transition-colors">Developer</a>
                 <a href="./privacy" class="text-gray-700 hover:text-indigo-600 transition-colors">Privacy</a>
                 <a href="./terms" class="text-gray-700 hover:text-indigo-600 transition-colors">Terms</a>
                 <a href="./cookies" class="text-indigo-600 transition-colors">Cookies</a>
@@ -97,7 +97,7 @@
         <div class="container mx-auto px-6 max-w-4xl">
             <div class="policy-section">
                 <h3 class="text-2xl font-bold text-gray-800">Introduction</h3>
-                <p class="text-gray-600">This Cookie Policy explains how BackupBot uses cookies and similar technologies on our website (backupbot.net), By using our website, you consent to the use of cookies as described in this policy.</p>
+                <p class="text-gray-600">This Cookie Policy explains how BackupBot uses cookies and similar technologies on our website (backupbot.is-cool.dev), By using our website, you consent to the use of cookies as described in this policy.</p>
             </div>
 
             <div class="policy-section">
@@ -169,7 +169,7 @@
 
             <div class="policy-section">
                 <h3 class="text-2xl font-bold text-gray-800">Contact Us</h3>
-                <p class="text-gray-600">If you have any questions about our Cookie Policy or our data practices or any other questions, please contact us through our <a href="https://discord.gg/Xnh5ckQVyV" class="text-indigo-600 hover:text-indigo-800">Discord support server</a> or through our <a href="mailto:andres@backupbot.net" class="text-indigo-600 hover:text-indigo-800">Email</a>.</p>
+                <p class="text-gray-600">If you have any questions about our Cookie Policy or our data practices or any other questions, please contact us through our <a href="https://discord.gg/Xnh5ckQVyV" class="text-indigo-600 hover:text-indigo-800">Discord support server</a> or through our <a href="mailto:andres@backupbot.is-cool.dev" class="text-indigo-600 hover:text-indigo-800">Email</a>.</p>
             </div>
 
             <div class="mt-12 text-sm text-gray-600 border-t pt-8">
@@ -198,15 +198,15 @@
             <div class="flex flex-col md:flex-row justify-between items-center">
                 <div class="flex items-center space-x-2 mb-6 md:mb-0">
                     <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-12 h-12" loading="lazy">
-                    <a href="https://backupbot.net/" class="text-2xl font-bold text-white hover:text-gray-300 transition-colors">BackupBot</a>
+                    <a href="https://backupbot.is-cool.dev/" class="text-2xl font-bold text-white hover:text-gray-300 transition-colors">BackupBot</a>
                 </div>
                 <div class="flex flex-wrap justify-center gap-4 mb-6 md:mb-0">
-                    <a href="https://backupbot.net/#features" class="text-gray-400 hover:text-white transition-colors">Features</a>
-                    <a href="https://backupbot.net/#how-to-use" class="text-gray-400 hover:text-white transition-colors">How To Use</a>
-                    <a href="https://backupbot.net/#commands" class="text-gray-400 hover:text-white transition-colors">Commands</a>
-                    <a href="https://backupbot.net/#faq" class="text-gray-400 hover:text-white transition-colors">FAQ</a>
-                    <a href="https://backupbot.net/#to-add" class="text-gray-400 hover:text-white transition-colors">Roadmap</a>
-                    <a href="https://backupbot.net/#developer" class="text-gray-400 hover:text-white transition-colors">Developer</a>
+                    <a href="https://backupbot.is-cool.dev/#features" class="text-gray-400 hover:text-white transition-colors">Features</a>
+                    <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-400 hover:text-white transition-colors">How To Use</a>
+                    <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-400 hover:text-white transition-colors">Commands</a>
+                    <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-400 hover:text-white transition-colors">FAQ</a>
+                    <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-400 hover:text-white transition-colors">Roadmap</a>
+                    <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-400 hover:text-white transition-colors">Developer</a>
                     <a href="./privacy" class="text-gray-400 hover:text-white transition-colors">Privacy Policy</a>
                     <a href="./terms" class="text-gray-400 hover:text-white transition-colors">Terms of Service</a>
                     <a href="./cookies" class="text-white transition-colors">Cookie Policy</a>

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
     <meta name="author" content="Andres99">
     <meta property="og:title" content="BackupBot - Server data saver">
     <meta property="og:description" content="Protect your Discord server with automated backups for channels, roles, emojis, and more!">
-    <meta property="og:image" content="https://backupbot.net/images/BackupBot-wide.png">
-    <meta property="og:url" content="https://backupbot.net">
+    <meta property="og:image" content="https://backupbot.is-cool.dev/images/BackupBot-wide.png">
+    <meta property="og:url" content="https://backupbot.is-cool.dev">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="google-adsense-account" content="ca-pub-3689168030425134">
     <title>BackupBot - Server data saver</title>
@@ -27,7 +27,7 @@
         <div class="flex justify-between items-center mb-8">
             <div class="flex items-center space-x-2">
                 <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-10 h-10" loading="lazy">
-                <a href="https://backupbot.net/" class="text-xl font-bold text-gray-800">BackupBot</a>
+                <a href="https://backupbot.is-cool.dev/" class="text-xl font-bold text-gray-800">BackupBot</a>
             </div>
             <button id="closeMenu" class="text-gray-500 hover:text-gray-700">
                 <i class="fas fa-times text-2xl"></i>
@@ -61,15 +61,15 @@
         <div class="container mx-auto px-6 py-3 flex justify-between items-center">
             <div class="flex items-center space-x-2">
                 <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-10 h-10" loading="lazy">
-                <a href="https://backupbot.net/" class="text-xl font-bold text-gray-800 hover:text-indigo-600 transition-colors">BackupBot</a>
+                <a href="https://backupbot.is-cool.dev/" class="text-xl font-bold text-gray-800 hover:text-indigo-600 transition-colors">BackupBot</a>
             </div>
             <div class="hidden md:flex space-x-6">
-                <a href="https://backupbot.net/#features" class="text-gray-700 hover:text-indigo-600 transition-colors">Features</a>
-                <a href="https://backupbot.net/#how-to-use" class="text-gray-700 hover:text-indigo-600 transition-colors">How To Use</a>
-                <a href="https://backupbot.net/#commands" class="text-gray-700 hover:text-indigo-600 transition-colors">Commands</a>
-                <a href="https://backupbot.net/#faq" class="text-gray-700 hover:text-indigo-600 transition-colors">FAQ</a>
-                <a href="https://backupbot.net/#to-add" class="text-gray-700 hover:text-indigo-600 transition-colors">Roadmap</a>
-                <a href="https://backupbot.net/#developer" class="text-gray-700 hover:text-indigo-600 transition-colors">Developer</a>
+                <a href="https://backupbot.is-cool.dev/#features" class="text-gray-700 hover:text-indigo-600 transition-colors">Features</a>
+                <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-700 hover:text-indigo-600 transition-colors">How To Use</a>
+                <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-700 hover:text-indigo-600 transition-colors">Commands</a>
+                <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-700 hover:text-indigo-600 transition-colors">FAQ</a>
+                <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-700 hover:text-indigo-600 transition-colors">Roadmap</a>
+                <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-700 hover:text-indigo-600 transition-colors">Developer</a>
                 <a href="./privacy" class="text-gray-700 hover:text-indigo-600 transition-colors">Privacy</a>
                 <a href="./terms" class="text-gray-700 hover:text-indigo-600 transition-colors">Terms</a>
                 <a href="./cookies" class="text-gray-700 hover:text-indigo-600 transition-colors">Cookies</a>
@@ -447,15 +447,15 @@
             <div class="flex flex-col md:flex-row justify-between items-center">
                 <div class="flex items-center space-x-2 mb-6 md:mb-0">
                     <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-12 h-12" loading="lazy">
-                    <a href="https://backupbot.net/" class="text-2xl font-bold text-white hover:text-gray-300 transition-colors">BackupBot</a>
+                    <a href="https://backupbot.is-cool.dev/" class="text-2xl font-bold text-white hover:text-gray-300 transition-colors">BackupBot</a>
                 </div>
                 <div class="flex flex-wrap justify-center gap-4 mb-6 md:mb-0">
-                    <a href="https://backupbot.net/#features" class="text-gray-400 hover:text-white transition-colors">Features</a>
-                    <a href="https://backupbot.net/#how-to-use" class="text-gray-400 hover:text-white transition-colors">How To Use</a>
-                    <a href="https://backupbot.net/#commands" class="text-gray-400 hover:text-white transition-colors">Commands</a>
-                    <a href="https://backupbot.net/#faq" class="text-gray-400 hover:text-white transition-colors">FAQ</a>
-                    <a href="https://backupbot.net/#to-add" class="text-gray-400 hover:text-white transition-colors">Roadmap</a>
-                    <a href="https://backupbot.net/#developer" class="text-gray-400 hover:text-white transition-colors">Developer</a>
+                    <a href="https://backupbot.is-cool.dev/#features" class="text-gray-400 hover:text-white transition-colors">Features</a>
+                    <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-400 hover:text-white transition-colors">How To Use</a>
+                    <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-400 hover:text-white transition-colors">Commands</a>
+                    <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-400 hover:text-white transition-colors">FAQ</a>
+                    <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-400 hover:text-white transition-colors">Roadmap</a>
+                    <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-400 hover:text-white transition-colors">Developer</a>
                     <a href="./privacy" class="text-gray-400 hover:text-white transition-colors">Privacy Policy</a>
                     <a href="./terms" class="text-gray-400 hover:text-white transition-colors">Terms of Service</a>
                     <a href="./cookies" class="text-gray-400 hover:text-white transition-colors">Cookie Policy</a>

--- a/privacy.html
+++ b/privacy.html
@@ -21,19 +21,19 @@
         <div class="flex justify-between items-center mb-8">
             <div class="flex items-center space-x-2">
                 <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-10 h-10" loading="lazy">
-                <a href="https://backupbot.net/" class="text-xl font-bold text-gray-800">BackupBot</a>
+                <a href="https://backupbot.is-cool.dev/" class="text-xl font-bold text-gray-800">BackupBot</a>
             </div>
             <button id="closeMenu" class="text-gray-500 hover:text-gray-700">
                 <i class="fas fa-times text-2xl"></i>
             </button>
         </div>
         <div class="flex flex-col space-y-4">
-            <a href="https://backupbot.net/#features" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Features</a>
-            <a href="https://backupbot.net/#how-to-use" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">How To Use</a>
-            <a href="https://backupbot.net/#commands" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Commands</a>
-            <a href="https://backupbot.net/#faq" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">FAQ</a>
-            <a href="https://backupbot.net/#to-add" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Roadmap</a>
-            <a href="https://backupbot.net/#developer" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Developer</a>
+            <a href="https://backupbot.is-cool.dev/#features" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Features</a>
+            <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">How To Use</a>
+            <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Commands</a>
+            <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">FAQ</a>
+            <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Roadmap</a>
+            <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Developer</a>
             <a href="./privacy" class="text-indigo-600 font-medium py-2 border-b border-gray-200">Privacy Policy</a>
             <a href="./terms" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Terms of Service</a>
             <a href="./cookies" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Cookie Policy</a>
@@ -55,15 +55,15 @@
         <div class="container mx-auto px-6 py-3 flex justify-between items-center">
             <div class="flex items-center space-x-2">
                 <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-10 h-10" loading="lazy">
-                <a href="https://backupbot.net/" class="text-xl font-bold text-gray-800 hover:text-indigo-600 transition-colors">BackupBot</a>
+                <a href="https://backupbot.is-cool.dev/" class="text-xl font-bold text-gray-800 hover:text-indigo-600 transition-colors">BackupBot</a>
             </div>
             <div class="hidden md:flex space-x-6">
-                <a href="https://backupbot.net/#features" class="text-gray-700 hover:text-indigo-600 transition-colors">Features</a>
-                <a href="https://backupbot.net/#how-to-use" class="text-gray-700 hover:text-indigo-600 transition-colors">How To Use</a>
-                <a href="https://backupbot.net/#commands" class="text-gray-700 hover:text-indigo-600 transition-colors">Commands</a>
-                <a href="https://backupbot.net/#faq" class="text-gray-700 hover:text-indigo-600 transition-colors">FAQ</a>
-                <a href="https://backupbot.net/#to-add" class="text-gray-700 hover:text-indigo-600 transition-colors">Roadmap</a>
-                <a href="https://backupbot.net/#developer" class="text-gray-700 hover:text-indigo-600 transition-colors">Developer</a>
+                <a href="https://backupbot.is-cool.dev/#features" class="text-gray-700 hover:text-indigo-600 transition-colors">Features</a>
+                <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-700 hover:text-indigo-600 transition-colors">How To Use</a>
+                <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-700 hover:text-indigo-600 transition-colors">Commands</a>
+                <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-700 hover:text-indigo-600 transition-colors">FAQ</a>
+                <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-700 hover:text-indigo-600 transition-colors">Roadmap</a>
+                <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-700 hover:text-indigo-600 transition-colors">Developer</a>
                 <a href="./privacy" class="text-indigo-600 transition-colors">Privacy</a>
                 <a href="./terms" class="text-gray-700 hover:text-indigo-600 transition-colors">Terms</a>
                 <a href="./cookies" class="text-gray-700 hover:text-indigo-600 transition-colors">Cookies</a>
@@ -151,7 +151,7 @@
 
                 <h4 class="text-xl font-semibold mt-6 mb-3 text-gray-700">Third-Party Services</h4>
                 <ul class="list-disc pl-6 text-gray-600 space-y-2">
-                    <li>For large backups, we use our CDN (cdn.backupbot.net) as a file hosting service. Files uploaded to our CDN are subject to Cloudflare's Privacy Policy, which is beyond our control.</li>
+                    <li>For large backups, we use our CDN (cdn.backupbot.is-cool.dev) as a file hosting service. Files uploaded to our CDN are subject to Cloudflare's Privacy Policy, which is beyond our control.</li>
                     <li>We use the Discord Bot API to interact with your server, and information/files shared with Discord are subject to their Privacy Policy, which is beyond our control.</li>
                 </ul>
             </div>
@@ -197,7 +197,7 @@
 
             <div class="policy-section">
                 <h3 class="text-2xl font-bold text-gray-800">Contact Us</h3>
-                <p class="text-gray-600">If you have any questions or concerns about this Privacy Policy or our data practices or any other questions, please contact us through our <a href="https://discord.gg/Xnh5ckQVyV" class="text-indigo-600 hover:text-indigo-800">Discord support server</a> or through our <a href="mailto:andres@backupbot.net" class="text-indigo-600 hover:text-indigo-800">Email</a>.</p>
+                <p class="text-gray-600">If you have any questions or concerns about this Privacy Policy or our data practices or any other questions, please contact us through our <a href="https://discord.gg/Xnh5ckQVyV" class="text-indigo-600 hover:text-indigo-800">Discord support server</a> or through our <a href="mailto:andres@backupbot.is-cool.dev" class="text-indigo-600 hover:text-indigo-800">Email</a>.</p>
             </div>
             <div class="mt-12 text-sm text-gray-600 border-t pt-8">
             <p>BackupBot © 2025 BackupBot Developer Andres99. BackupBot and the BackupBot logo are trademarks of BackupBot Developer Andres99.,  registered in Iraq and other countries, Discord and the Discord logo are trademarks of Discord Inc., registered in the U.S. and other countries. Cloudflare and the Cloudflare logo are trademarks of Cloudflare Inc., registered in the U.S. and other countries, All other trademarks, logos and copyrights are property of their respective owners. All rights reserved.</p>
@@ -224,15 +224,15 @@
             <div class="flex flex-col md:flex-row justify-between items-center">
                 <div class="flex items-center space-x-2 mb-6 md:mb-0">
                     <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-12 h-12" loading="lazy">
-                    <a href="https://backupbot.net/" class="text-2xl font-bold text-white hover:text-gray-300 transition-colors">BackupBot</a>
+                    <a href="https://backupbot.is-cool.dev/" class="text-2xl font-bold text-white hover:text-gray-300 transition-colors">BackupBot</a>
                 </div>
                 <div class="flex flex-wrap justify-center gap-4 mb-6 md:mb-0">
-                    <a href="https://backupbot.net/#features" class="text-gray-400 hover:text-white transition-colors">Features</a>
-                    <a href="https://backupbot.net/#how-to-use" class="text-gray-400 hover:text-white transition-colors">How To Use</a>
-                    <a href="https://backupbot.net/#commands" class="text-gray-400 hover:text-white transition-colors">Commands</a>
-                    <a href="https://backupbot.net/#faq" class="text-gray-400 hover:text-white transition-colors">FAQ</a>
-                    <a href="https://backupbot.net/#to-add" class="text-gray-400 hover:text-white transition-colors">Roadmap</a>
-                    <a href="https://backupbot.net/#developer" class="text-gray-400 hover:text-white transition-colors">Developer</a>
+                    <a href="https://backupbot.is-cool.dev/#features" class="text-gray-400 hover:text-white transition-colors">Features</a>
+                    <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-400 hover:text-white transition-colors">How To Use</a>
+                    <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-400 hover:text-white transition-colors">Commands</a>
+                    <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-400 hover:text-white transition-colors">FAQ</a>
+                    <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-400 hover:text-white transition-colors">Roadmap</a>
+                    <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-400 hover:text-white transition-colors">Developer</a>
                     <a href="./privacy" class="text-white transition-colors">Privacy Policy</a>
                     <a href="./terms" class="text-gray-400 hover:text-white transition-colors">Terms of Service</a>
                     <a href="./cookies" class="text-gray-400 hover:text-white transition-colors">Cookie Policy</a>

--- a/redirect/invite.html
+++ b/redirect/invite.html
@@ -8,7 +8,7 @@
     <meta name="author" content="Andres99">
     <meta property="og:title" content="BackupBot Authorization">
     <meta property="og:description" content="Add BackupBot to your Discord server today for automated backups!">
-    <meta property="og:url" content="https://backupbot.net/auth">
+    <meta property="og:url" content="https://backupbot.is-cool.dev/auth">
     <title>Add BackupBot</title>
     <link rel="icon" href="../images/BackupBot.png" type="image/png">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
@@ -25,7 +25,7 @@
         <div class="flex justify-between items-center mb-8">
             <div class="flex items-center space-x-2">
                 <img src="../images/BackupBot.png" alt="BackupBot Logo" class="w-10 h-10" loading="lazy">
-                <a href="https://backupbot.net/" class="text-xl font-bold text-gray-800">BackupBot</a>
+                <a href="https://backupbot.is-cool.dev/" class="text-xl font-bold text-gray-800">BackupBot</a>
             </div>
             <button id="closeMenu" class="text-gray-500 hover:text-gray-700">
                 <i class="fas fa-times text-2xl"></i>
@@ -56,7 +56,7 @@
         <div class="container mx-auto px-6 py-3 flex justify-between items-center">
             <div class="flex items-center space-x-2">
                 <img src="../images/BackupBot.png" alt="BackupBot Logo" class="w-10 h-10" loading="lazy">
-                <a href="https://backupbot.net/" class="text-xl font-bold text-gray-800 hover:text-indigo-600 transition-colors">BackupBot</a>
+                <a href="https://backupbot.is-cool.dev/" class="text-xl font-bold text-gray-800 hover:text-indigo-600 transition-colors">BackupBot</a>
             </div>
             <div class="hidden md:flex space-x-6">
                 <a href="../#features" class="text-gray-700 hover:text-indigo-600 transition-colors">Features</a>
@@ -108,7 +108,7 @@
             <div class="flex flex-col md:flex-row justify-between items-center">
                 <div class="flex items-center space-x-2 mb-6 md:mb-0">
                     <img src="../images/BackupBot.png" alt="BackupBot Logo" class="w-12 h-12" loading="lazy">
-                    <a href="https://backupbot.net/" class="text-2xl font-bold text-white hover:text-gray-300 transition-colors">BackupBot</a>
+                    <a href="https://backupbot.is-cool.dev/" class="text-2xl font-bold text-white hover:text-gray-300 transition-colors">BackupBot</a>
                 </div>
                 <div class="flex space-x-4">
                     <a href="https://github.com/BackupBotlol" class="text-gray-400 hover:text-white transition-colors">

--- a/redirect/server.html
+++ b/redirect/server.html
@@ -8,7 +8,7 @@
     <meta name="author" content="Andres99">
     <meta property="og:title" content="BackupBot Support Server">
     <meta property="og:description" content="Join our Discord support server for support with BackupBot">
-    <meta property="og:url" content="https://backupbot.net/invite">
+    <meta property="og:url" content="https://backupbot.is-cool.dev/invite">
     <title>BackupBot Support Server</title>
     <link rel="icon" href="../images/BackupBot.png" type="image/png">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
@@ -25,19 +25,19 @@
         <div class="flex justify-between items-center mb-8">
             <div class="flex items-center space-x-2">
                 <img src="../images/BackupBot.png" alt="BackupBot Logo" class="w-10 h-10" loading="lazy">
-                <a href="https://backupbot.net/" class="text-xl font-bold text-gray-800">BackupBot</a>
+                <a href="https://backupbot.is-cool.dev/" class="text-xl font-bold text-gray-800">BackupBot</a>
             </div>
             <button id="closeMenu" class="text-gray-500 hover:text-gray-700">
                 <i class="fas fa-times text-2xl"></i>
             </button>
         </div>
         <div class="flex flex-col space-y-4">
-            <a href="https://backupbot.net/#features" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Features</a>
-            <a href="https://backupbot.net/#how-to-use" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">How To Use</a>
-            <a href="https://backupbot.net/#commands" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Commands</a>
-            <a href="https://backupbot.net/#faq" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">FAQ</a>
-            <a href="https://backupbot.net/#to-add" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Roadmap</a>
-            <a href="https://backupbot.net/#developer" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Developer</a>
+            <a href="https://backupbot.is-cool.dev/#features" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Features</a>
+            <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">How To Use</a>
+            <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Commands</a>
+            <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">FAQ</a>
+            <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Roadmap</a>
+            <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Developer</a>
             <a href="../privacy" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Privacy Policy</a>
             <a href="../terms" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Terms of Service</a>
             <a href="../cookies" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Cookie Policy</a>
@@ -56,15 +56,15 @@
         <div class="container mx-auto px-6 py-3 flex justify-between items-center">
             <div class="flex items-center space-x-2">
                 <img src="../images/BackupBot.png" alt="BackupBot Logo" class="w-10 h-10" loading="lazy">
-                <a href="https://backupbot.net/" class="text-xl font-bold text-gray-800 hover:text-indigo-600 transition-colors">BackupBot</a>
+                <a href="https://backupbot.is-cool.dev/" class="text-xl font-bold text-gray-800 hover:text-indigo-600 transition-colors">BackupBot</a>
             </div>
             <div class="hidden md:flex space-x-6">
-                <a href="https://backupbot.net/#features" class="text-gray-700 hover:text-indigo-600 transition-colors">Features</a>
-                <a href="https://backupbot.net/#how-to-use" class="text-gray-700 hover:text-indigo-600 transition-colors">How To Use</a>
-                <a href="https://backupbot.net/#commands" class="text-gray-700 hover:text-indigo-600 transition-colors">Commands</a>
-                <a href="https://backupbot.net/#faq" class="text-gray-700 hover:text-indigo-600 transition-colors">FAQ</a>
-                <a href="https://backupbot.net/#to-add" class="text-gray-700 hover:text-indigo-600 transition-colors">Roadmap</a>
-                <a href="https://backupbot.net/#developer" class="text-gray-700 hover:text-indigo-600 transition-colors">Developer</a>
+                <a href="https://backupbot.is-cool.dev/#features" class="text-gray-700 hover:text-indigo-600 transition-colors">Features</a>
+                <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-700 hover:text-indigo-600 transition-colors">How To Use</a>
+                <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-700 hover:text-indigo-600 transition-colors">Commands</a>
+                <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-700 hover:text-indigo-600 transition-colors">FAQ</a>
+                <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-700 hover:text-indigo-600 transition-colors">Roadmap</a>
+                <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-700 hover:text-indigo-600 transition-colors">Developer</a>
                 <a href="../privacy" class="text-gray-700 hover:text-indigo-600 transition-colors">Privacy</a>
                 <a href="../terms" class="text-gray-700 hover:text-indigo-600 transition-colors">Terms</a>
                 <a href="../cookies" class="text-gray-700 hover:text-indigo-600 transition-colors">Cookies</a>
@@ -108,7 +108,7 @@
             <div class="flex flex-col md:flex-row justify-between items-center">
                 <div class="flex items-center space-x-2 mb-6 md:mb-0">
                     <img src="../images/BackupBot.png" alt="BackupBot Logo" class="w-12 h-12" loading="lazy">
-                    <a href="https://backupbot.net/" class="text-2xl font-bold text-white hover:text-gray-300 transition-colors">BackupBot</a>
+                    <a href="https://backupbot.is-cool.dev/" class="text-2xl font-bold text-white hover:text-gray-300 transition-colors">BackupBot</a>
                 </div>
                 <div class="flex space-x-4">
                     <a href="https://github.com/BackupBotlol" class="text-gray-400 hover:text-white transition-colors">

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,5 @@
 # If you have any questions about this, ask them on the Github repo or contact us
-# Sitemap: https://backupbot.net/sitemap.xml
+# Sitemap: https://backupbot.is-cool.dev/sitemap.xml
 
 User-agent: *
 Disallow: /.git/

--- a/script.js
+++ b/script.js
@@ -162,7 +162,7 @@ function initFAQAccordion() {
 
 async function fetchStatsAndInitCounters() {
     try {
-        const response = await fetch('https://backupbot.net/stats.json');
+        const response = await fetch('https://backupbot.is-cool.dev/stats.json');
         if (response.ok) {
             const stats = await response.json();
             

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -8,32 +8,32 @@
 
 
 <url>
-  <loc>https://backupbot.net/</loc>
+  <loc>https://backupbot.is-cool.dev/</loc>
   <lastmod>2025-06-11T01:03:26+00:00</lastmod>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://backupbot.net/privacy</loc>
+  <loc>https://backupbot.is-cool.dev/privacy</loc>
   <lastmod>2025-06-11T01:03:26+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://backupbot.net/terms</loc>
+  <loc>https://backupbot.is-cool.dev/terms</loc>
   <lastmod>2025-06-11T01:03:26+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://backupbot.net/cookies</loc>
+  <loc>https://backupbot.is-cool.dev/cookies</loc>
   <lastmod>2025-06-11T01:03:26+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://backupbot.net/redirect/invite</loc>
+  <loc>https://backupbot.is-cool.dev/redirect/invite</loc>
   <lastmod>2025-06-11T01:03:26+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://backupbot.net/redirect/server</loc>
+  <loc>https://backupbot.is-cool.dev/redirect/server</loc>
   <lastmod>2025-06-11T01:03:26+00:00</lastmod>
   <priority>0.80</priority>
 </url>

--- a/terms.html
+++ b/terms.html
@@ -21,19 +21,19 @@
         <div class="flex justify-between items-center mb-8">
             <div class="flex items-center space-x-2">
                 <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-10 h-10" loading="lazy">
-                <a href="https://backupbot.net/" class="text-xl font-bold text-gray-800">BackupBot</a>
+                <a href="https://backupbot.is-cool.dev/" class="text-xl font-bold text-gray-800">BackupBot</a>
             </div>
             <button id="closeMenu" class="text-gray-500 hover:text-gray-700">
                 <i class="fas fa-times text-2xl"></i>
             </button>
         </div>
         <div class="flex flex-col space-y-4">
-            <a href="https://backupbot.net/#features" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Features</a>
-            <a href="https://backupbot.net/#how-to-use" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">How To Use</a>
-            <a href="https://backupbot.net/#commands" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Commands</a>
-            <a href="https://backupbot.net/#faq" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">FAQ</a>
-            <a href="https://backupbot.net/#to-add" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Roadmap</a>
-            <a href="https://backupbot.net/#developer" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Developer</a>
+            <a href="https://backupbot.is-cool.dev/#features" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Features</a>
+            <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">How To Use</a>
+            <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Commands</a>
+            <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">FAQ</a>
+            <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Roadmap</a>
+            <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Developer</a>
             <a href="./privacy" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Privacy Policy</a>
             <a href="./terms" class="text-indigo-600 font-medium py-2 border-b border-gray-200">Terms of Service</a>
             <a href="./cookies" class="text-gray-700 hover:text-indigo-600 py-2 border-b border-gray-200">Cookie Policy</a>
@@ -55,15 +55,15 @@
         <div class="container mx-auto px-6 py-3 flex justify-between items-center">
             <div class="flex items-center space-x-2">
                 <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-10 h-10" loading="lazy">
-                <a href="https://backupbot.net/" class="text-xl font-bold text-gray-800 hover:text-indigo-600 transition-colors">BackupBot</a>
+                <a href="https://backupbot.is-cool.dev/" class="text-xl font-bold text-gray-800 hover:text-indigo-600 transition-colors">BackupBot</a>
             </div>
             <div class="hidden md:flex space-x-6">
-                <a href="https://backupbot.net/#features" class="text-gray-700 hover:text-indigo-600 transition-colors">Features</a>
-                <a href="https://backupbot.net/#how-to-use" class="text-gray-700 hover:text-indigo-600 transition-colors">How To Use</a>
-                <a href="https://backupbot.net/#commands" class="text-gray-700 hover:text-indigo-600 transition-colors">Commands</a>
-                <a href="https://backupbot.net/#faq" class="text-gray-700 hover:text-indigo-600 transition-colors">FAQ</a>
-                <a href="https://backupbot.net/#to-add" class="text-gray-700 hover:text-indigo-600 transition-colors">Roadmap</a>
-                <a href="https://backupbot.net/#developer" class="text-gray-700 hover:text-indigo-600 transition-colors">Developer</a>
+                <a href="https://backupbot.is-cool.dev/#features" class="text-gray-700 hover:text-indigo-600 transition-colors">Features</a>
+                <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-700 hover:text-indigo-600 transition-colors">How To Use</a>
+                <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-700 hover:text-indigo-600 transition-colors">Commands</a>
+                <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-700 hover:text-indigo-600 transition-colors">FAQ</a>
+                <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-700 hover:text-indigo-600 transition-colors">Roadmap</a>
+                <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-700 hover:text-indigo-600 transition-colors">Developer</a>
                 <a href="./privacy" class="text-gray-700 hover:text-indigo-600 transition-colors">Privacy</a>
                 <a href="./terms" class="text-indigo-600 transition-colors">Terms</a>
                 <a href="./cookies" class="text-gray-700 hover:text-indigo-600 transition-colors">Cookies</a>
@@ -192,7 +192,7 @@
                 <p class="text-gray-700 mb-8">You agree to defend, indemnify, and hold harmless BackupBot and its developer from and against any claims, liabilities, damages, losses, and expenses, including without limitation reasonable attorney fees and costs, arising out of or in any way connected with your use of the service.</p>
                 
                 <h2 class="text-2xl font-bold text-gray-800 mb-6">Third-Party Services</h2>
-                <p class="text-gray-700 mb-8">Our service may utilize third-party services, such as Discord API and our CDN service (cdn.backupbot.net). Use of these services is subject to their respective terms of service and privacy policies, which is beyond our control.</p>
+                <p class="text-gray-700 mb-8">Our service may utilize third-party services, such as Discord API and our CDN service (cdn.backupbot.is-cool.dev). Use of these services is subject to their respective terms of service and privacy policies, which is beyond our control.</p>
                 
                 <h2 class="text-2xl font-bold text-gray-800 mb-6">Termination</h2>
                 <p class="text-gray-700 mb-8">We may terminate or suspend your access to our service immediately, without prior notice or liability, for any reason whatsoever, including without limitation if you breach the Terms.</p>
@@ -204,7 +204,7 @@
                 <p class="text-gray-700 mb-8">We may update these Terms of Service from time to time. We will (or won't) notify users of significant changes through our Discord support server or through direct announcement in your log channel.</p>
                 
                 <h2 class="text-2xl font-bold text-gray-800 mb-6">Contact Us</h2>
-                <p class="text-gray-700 mb-8">If you have any questions about these Terms of Service or our data practices or any other questions, please contact us through our <a href="https://discord.gg/Xnh5ckQVyV" class="text-indigo-600 hover:text-indigo-800">Discord support server</a> or through our <a href="mailto:andres@backupbot.net" class="text-indigo-600 hover:text-indigo-800">Email</a>.</p>
+                <p class="text-gray-700 mb-8">If you have any questions about these Terms of Service or our data practices or any other questions, please contact us through our <a href="https://discord.gg/Xnh5ckQVyV" class="text-indigo-600 hover:text-indigo-800">Discord support server</a> or through our <a href="mailto:andres@backupbot.is-cool.dev" class="text-indigo-600 hover:text-indigo-800">Email</a>.</p>
                 
                 <div class="mt-12 text-sm text-gray-600 border-t pt-8">
                     <p>BackupBot © 2025 BackupBot Developer Andres99. BackupBot and the BackupBot logo are trademarks of BackupBot Developer Andres99.,  registered in Iraq and other countries, Discord and the Discord logo are trademarks of Discord Inc., registered in the U.S. and other countries. Cloudflare and the Cloudflare logo are trademarks of Cloudflare Inc., registered in the U.S. and other countries, All other trademarks, logos and copyrights are property of their respective owners. All rights reserved.</p>
@@ -233,15 +233,15 @@
             <div class="flex flex-col md:flex-row justify-between items-center">
                 <div class="flex items-center space-x-2 mb-6 md:mb-0">
                     <img src="images/BackupBot.png" alt="BackupBot Logo" class="w-12 h-12" loading="lazy">
-                    <a href="https://backupbot.net/" class="text-2xl font-bold text-white hover:text-gray-300 transition-colors">BackupBot</a>
+                    <a href="https://backupbot.is-cool.dev/" class="text-2xl font-bold text-white hover:text-gray-300 transition-colors">BackupBot</a>
                 </div>
                 <div class="flex flex-wrap justify-center gap-4 mb-6 md:mb-0">
-                    <a href="https://backupbot.net/#features" class="text-gray-400 hover:text-white transition-colors">Features</a>
-                    <a href="https://backupbot.net/#how-to-use" class="text-gray-400 hover:text-white transition-colors">How To Use</a>
-                    <a href="https://backupbot.net/#commands" class="text-gray-400 hover:text-white transition-colors">Commands</a>
-                    <a href="https://backupbot.net/#faq" class="text-gray-400 hover:text-white transition-colors">FAQ</a>
-                    <a href="https://backupbot.net/#to-add" class="text-gray-400 hover:text-white transition-colors">Roadmap</a>
-                    <a href="https://backupbot.net/#developer" class="text-gray-400 hover:text-white transition-colors">Developer</a>
+                    <a href="https://backupbot.is-cool.dev/#features" class="text-gray-400 hover:text-white transition-colors">Features</a>
+                    <a href="https://backupbot.is-cool.dev/#how-to-use" class="text-gray-400 hover:text-white transition-colors">How To Use</a>
+                    <a href="https://backupbot.is-cool.dev/#commands" class="text-gray-400 hover:text-white transition-colors">Commands</a>
+                    <a href="https://backupbot.is-cool.dev/#faq" class="text-gray-400 hover:text-white transition-colors">FAQ</a>
+                    <a href="https://backupbot.is-cool.dev/#to-add" class="text-gray-400 hover:text-white transition-colors">Roadmap</a>
+                    <a href="https://backupbot.is-cool.dev/#developer" class="text-gray-400 hover:text-white transition-colors">Developer</a>
                     <a href="./privacy" class="text-gray-400 hover:text-white transition-colors">Privacy Policy</a>
                     <a href="./terms" class="text-white transition-colors">Terms of Service</a>
                     <a href="./cookies" class="text-gray-400 hover:text-white transition-colors">Cookie Policy</a>


### PR DESCRIPTION
## Summary
- replace all references to backupbot.net with backupbot.is-cool.dev across the static pages
- update contact email, CDN references, and scripts to point at the new domain
- refresh sitemap and robots.txt entries to use the new hostname

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf2d3d2a888329ab88a87d0c9d066a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Chores
  - Migrated all public-facing links, navigation, headers/footers, and Open Graph metadata to backupbot.is-cool.dev.
  - Updated contact email to andres@backupbot.is-cool.dev.
  - Switched CDN and stats endpoint to the new domain.
  - Updated sitemap and robots directives to reference the new domain.
- Documentation
  - Revised README heading and license links to use backupbot.is-cool.dev.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->